### PR TITLE
🔧 package: add `type`, required by nargo v10

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -1,7 +1,8 @@
 [package]
 name="noir_merkleroot"
 authors = ["tomo<tomoima525@gmail.com>"]
-compiler_version = "0.7.1"
+compiler_version = ">=0.7.1"
 license = "MIT"
+type = "lib"
 
 [dependencies]


### PR DESCRIPTION
package field `type` is now required by nargo v10:
- https://github.com/noir-lang/noir/pull/2134
- https://github.com/noir-lang/noir/releases/tag/v0.10.0